### PR TITLE
[Debugging]: Removed movement logger

### DIFF
--- a/Assets/MovementScripts/PlayerScripts/PlayerMovement.cs
+++ b/Assets/MovementScripts/PlayerScripts/PlayerMovement.cs
@@ -111,7 +111,6 @@ public class PlayerMovement : MonoBehaviour
                 rotation = 0;
             else
             {
-                Debug.Log("This is working!");
                 rotation = -1;
             }
 


### PR DESCRIPTION
Removing this for now so I can make changes without being spammed in the console.

Remove the logging for movement so that you're not constantly spammed with "This is working" in Unity's console. We know it works and if need be, it can be added back.